### PR TITLE
Huobi feed code fix

### DIFF
--- a/code/processes/huobifeed.q
+++ b/code/processes/huobifeed.q
@@ -3,7 +3,7 @@
 
 \d .huobi
 
-syms.crypto.symmap'[:exec sym from .crypto.symconfig where huobisym;`huobisym]
+syms:.crypto.symmap'[exec sym from .crypto.symconfig where huobisym;`huobisym]
 
 .huobi.prev:([]time:`timestamp$(); sym:`g#`symbol$();exchangeTime:`timestamp$();bid:(); bidSize:(); ask:();askSize:())
 


### PR DESCRIPTION
There was a slight error in huobifeed.q where .huobi.syms is defined, preventing the feed from starting. This pull request corrects said error.