### PR TITLE
added connection to standard tickerplant only; fixed up whitespace

### DIFF
--- a/appconfig/settings/rdb.q
+++ b/appconfig/settings/rdb.q
@@ -1,11 +1,11 @@
-// Bespoke RDB config : Finance Starter Pack
+// Bespoke RDB config for TorQ Crypto
 
 \d .rdb
-hdbdir:hsym`$getenv[`KDBHDB]    //the location of the hdb directory
-reloadenabled:1b		//if true, the RDB will not save when .u.end is called but
-               			//will clear it's data using reload function (called by the WDB)
-
-hdbtypes:()			//connection to HDB not needed
+hdbdir:hsym`$getenv[`KDBHDB]    // the location of the hdb directory
+reloadenabled:1b                // if true, the RDB will not save when .u.end is called but
+                                // will clear it's data using reload function (called by the WDB)
+tickerplanttypes:`tickerplant   // connect to a standard tickerplant (not segemented)
+hdbtypes:()                     // connection to HDB not needed
 
 \d .servers
-CONNECTIONS:enlist `tickerplant
+CONNECTIONS:enlist `tickerplant // connect to tickerplant only

--- a/appconfig/settings/wdb.q
+++ b/appconfig/settings/wdb.q
@@ -1,9 +1,10 @@
-// Bespoke WDB config : Finance Starter Pack
+// Bespoke WDB config for TorQ Crypto
 
 \d .wdb
-savedir:hsym `$getenv[`KDBWDB]		// location to save wdb data
+savedir:hsym `$getenv[`KDBWDB]          // location to save wdb data
 hdbdir:hsym`$getenv[`KDBHDB]            // move wdb database to different location
-sortslavetypes:()			// WDB doesn't need to connect to sortslaves
+sortslavetypes:()                       // WDB doesn't need to connect to sortslaves
+tickerplanttypes:`tickerplant           // connect to a standard tickerplant (not segemented)
 
 \d .servers
 CONNECTIONS:`tickerplant`sort`gateway`rdb`hdb


### PR DESCRIPTION
TorQ Crypto was inheriting some default config and was trying to connect to a segmented tickerplant which wasn't available. Fix is to ensure that it only tries to connect to standard tickerplant. Also fixed up some whitespace.